### PR TITLE
os_architecture option added

### DIFF
--- a/bare-metal/flatcar-linux/kubernetes/butane/install.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/butane/install.yaml
@@ -35,6 +35,7 @@ storage:
             -d ${install_disk} \
             -C ${os_channel} \
             -V ${os_version} \
+            -B ${os_architecture}-usr \
             ${baseurl_flag} \
             -i ignition.json
           udevadm settle

--- a/bare-metal/flatcar-linux/kubernetes/profiles.tf
+++ b/bare-metal/flatcar-linux/kubernetes/profiles.tf
@@ -2,9 +2,9 @@ locals {
   # flatcar-stable -> stable channel
   channel = split("-", var.os_channel)[1]
 
-  remote_kernel = "${var.download_protocol}://${local.channel}.release.flatcar-linux.net/amd64-usr/${var.os_version}/flatcar_production_pxe.vmlinuz"
+  remote_kernel = "${var.download_protocol}://${local.channel}.release.flatcar-linux.net/${var.os_architecture}-usr/${var.os_version}/flatcar_production_pxe.vmlinuz"
   remote_initrd = [
-    "${var.download_protocol}://${local.channel}.release.flatcar-linux.net/amd64-usr/${var.os_version}/flatcar_production_pxe_image.cpio.gz",
+    "${var.download_protocol}://${local.channel}.release.flatcar-linux.net/${var.os_architecture}-usr/${var.os_version}/flatcar_production_pxe_image.cpio.gz",
   ]
   args = [
     "initrd=flatcar_production_pxe_image.cpio.gz",
@@ -12,9 +12,9 @@ locals {
     "flatcar.first_boot=yes",
   ]
 
-  cached_kernel = "/assets/flatcar/${var.os_version}/flatcar_production_pxe.vmlinuz"
+  cached_kernel = "/assets/flatcar/${var.os_architecture}/${var.os_version}/flatcar_production_pxe.vmlinuz"
   cached_initrd = [
-    "/assets/flatcar/${var.os_version}/flatcar_production_pxe_image.cpio.gz",
+    "/assets/flatcar/${var.os_architecture}/${var.os_version}/flatcar_production_pxe_image.cpio.gz",
   ]
 
   kernel = var.cached_install ? local.cached_kernel : local.remote_kernel
@@ -51,6 +51,7 @@ data "ct_config" "install" {
   content = templatefile("${path.module}/butane/install.yaml", {
     os_channel         = local.channel
     os_version         = var.os_version
+    os_architecture    = var.os_architecture
     ignition_endpoint  = format("%s/ignition", var.matchbox_http_endpoint)
     mac                = concat(var.controllers.*.mac, var.workers.*.mac)[count.index]
     install_disk       = var.install_disk

--- a/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -156,6 +156,12 @@ variable "enable_aggregation" {
   default     = true
 }
 
+variable "os_architecture" {
+  type        = string
+  description = "CPU architecture of the node"
+  default     = "amd64"
+}
+
 # unofficial, undocumented, unsupported
 
 variable "cluster_domain_suffix" {

--- a/bare-metal/flatcar-linux/kubernetes/worker/butane/install.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/worker/butane/install.yaml
@@ -35,6 +35,7 @@ storage:
             -d ${install_disk} \
             -C ${os_channel} \
             -V ${os_version} \
+            -B ${os_architecture}-usr \
             ${baseurl_flag} \
             -i ignition.json
           udevadm settle

--- a/bare-metal/flatcar-linux/kubernetes/worker/matchbox.tf
+++ b/bare-metal/flatcar-linux/kubernetes/worker/matchbox.tf
@@ -2,9 +2,9 @@ locals {
   # flatcar-stable -> stable channel
   channel = split("-", var.os_channel)[1]
 
-  remote_kernel = "${var.download_protocol}://${local.channel}.release.flatcar-linux.net/amd64-usr/${var.os_version}/flatcar_production_pxe.vmlinuz"
+  remote_kernel = "${var.download_protocol}://${local.channel}.release.flatcar-linux.net/${var.os_architecture}-usr/${var.os_version}/flatcar_production_pxe.vmlinuz"
   remote_initrd = [
-    "${var.download_protocol}://${local.channel}.release.flatcar-linux.net/amd64-usr/${var.os_version}/flatcar_production_pxe_image.cpio.gz",
+    "${var.download_protocol}://${local.channel}.release.flatcar-linux.net/${var.os_architecture}-usr/${var.os_version}/flatcar_production_pxe_image.cpio.gz",
   ]
   args = flatten([
     "initrd=flatcar_production_pxe_image.cpio.gz",
@@ -46,6 +46,7 @@ data "ct_config" "install" {
   content = templatefile("${path.module}/butane/install.yaml", {
     os_channel         = local.channel
     os_version         = var.os_version
+    os_architecture    = var.os_architecture
     ignition_endpoint  = format("%s/ignition", var.matchbox_http_endpoint)
     mac                = var.mac
     install_disk       = var.install_disk

--- a/bare-metal/flatcar-linux/kubernetes/worker/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/worker/variables.tf
@@ -98,6 +98,12 @@ variable "kernel_args" {
   default     = []
 }
 
+variable "os_architecture" {
+  type        = string
+  description = "CPU architecture of the node"
+  default     = "amd64"
+}
+
 # unofficial, undocumented, unsupported
 
 variable "service_cidr" {

--- a/bare-metal/flatcar-linux/kubernetes/workers.tf
+++ b/bare-metal/flatcar-linux/kubernetes/workers.tf
@@ -28,5 +28,6 @@ module "workers" {
   cached_install    = var.cached_install
   install_disk      = var.install_disk
   kernel_args       = var.kernel_args
+  os_architecture   = var.os_architecture
 }
 


### PR DESCRIPTION
Until now, typhoon with flatcar-linux on bare metal was only available for machines with an AMD64 (x86_64) architecture. This means there is no currently no support of ARM64 (aarch64) machines. In this commit, the support for different architectures on flatcar-linux with bare-metal was added. This was done through the addition of an os_architecture variable which replaces the hardcoding of the "amd64" string in some places, such as in the links to the flatcar-linux releases