### PR TITLE
Added an optional extra variable (a map) for machine identification

### DIFF
--- a/bare-metal/flatcar-linux/kubernetes/butane/install.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/butane/install.yaml
@@ -30,7 +30,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -ex
-          curl --retry 10 "${ignition_endpoint}?mac=${mac}&os=installed" -o ignition.json
+          curl --retry 10 "${ignition_endpoint}?${extra_selectors}mac=${mac}&os=installed" -o ignition.json
           flatcar-install \
             -d ${install_disk} \
             -C ${os_channel} \

--- a/bare-metal/flatcar-linux/kubernetes/profiles.tf
+++ b/bare-metal/flatcar-linux/kubernetes/profiles.tf
@@ -8,7 +8,7 @@ locals {
   ]
   args = [
     "initrd=flatcar_production_pxe_image.cpio.gz",
-    "flatcar.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
+    "flatcar.config.url=${var.matchbox_http_endpoint}/ignition?$${extra_selectors}mac=$${mac:hexhyp}",
     "flatcar.first_boot=yes",
   ]
 
@@ -28,7 +28,8 @@ resource "matchbox_group" "install" {
   name    = format("install-%s", var.controllers[count.index].name)
   profile = matchbox_profile.install[count.index].name
   selector = {
-    mac = concat(var.controllers.*.mac, var.workers.*.mac)[count.index]
+    mac             = concat(var.controllers.*.mac, var.workers.*.mac)[count.index]
+    extra_selectors = "${concat([for key, value in var.controllers.*.extra_selectors : "${urlencode(key)}=${urlencode(value)}&"])}${concat([for key, value in var.workers.*.extra_selectors : "${urlencode(key)}=${urlencode(value)}&"])}"
   }
 }
 
@@ -53,6 +54,7 @@ data "ct_config" "install" {
     os_version         = var.os_version
     ignition_endpoint  = format("%s/ignition", var.matchbox_http_endpoint)
     mac                = concat(var.controllers.*.mac, var.workers.*.mac)[count.index]
+    extra_selectors    = "${concat([for key, value in var.controllers.*.extra_selectors : "${urlencode(key)}=${urlencode(value)}&"])}${concat([for key, value in var.workers.*.extra_selectors : "${urlencode(key)}=${urlencode(value)}&"])}"
     install_disk       = var.install_disk
     ssh_authorized_key = var.ssh_authorized_key
     # only cached profile adds -b baseurl
@@ -67,8 +69,9 @@ resource "matchbox_group" "controller" {
   name    = format("%s-%s", var.cluster_name, var.controllers[count.index].name)
   profile = matchbox_profile.controllers[count.index].name
   selector = {
-    mac = var.controllers[count.index].mac
-    os  = "installed"
+    mac             = var.controllers[count.index].mac
+    extra_selectors = concat([for key, value in var.controllers.*.extra_selectors : "${urlencode(key)}=${urlencode(value)}&"])
+    os              = "installed"
   }
 }
 
@@ -85,7 +88,7 @@ data "ct_config" "controllers" {
   content = templatefile("${path.module}/butane/controller.yaml", {
     domain_name            = var.controllers.*.domain[count.index]
     etcd_name              = var.controllers.*.name[count.index]
-    etcd_initial_cluster   = join(",", formatlist("%s=https://%s:2380", var.controllers.*.name, var.controllers.*.domain))
+    etcd_initial_cluster   = join("", formatlist("%s=https://%s:2380", var.controllers.*.name, var.controllers.*.domain))
     cluster_dns_service_ip = module.bootstrap.cluster_dns_service_ip
     cluster_domain_suffix  = var.cluster_domain_suffix
     ssh_authorized_key     = var.ssh_authorized_key

--- a/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -32,10 +32,11 @@ variable "controllers" {
     name   = string
     mac    = string
     domain = string
+    extra_selectors = optional(map(string), {})
   }))
   description = <<EOD
-List of controller machine details (unique name, identifying MAC address, FQDN)
-[{ name = "node1", mac = "52:54:00:a1:9c:ae", domain = "node1.example.com"}]
+List of controller machine details (unique name, identifying MAC address, FQDN, other identifiying fields (for example, CPU architecture or UUID))
+[{ name = "node1", mac = "52:54:00:a1:9c:ae", domain = "node1.example.com", {"uuid":"123e4567-e89b-12d3-a456-426614174000"}}]
 EOD
 }
 
@@ -44,12 +45,13 @@ variable "workers" {
     name   = string
     mac    = string
     domain = string
+    extra_selectors = optional(map(string), {})
   }))
   description = <<EOD
-List of worker machine details (unique name, identifying MAC address, FQDN)
+List of worker machine details (unique name, identifying MAC address, FQDN, other identifiying fields (for example, CPU architecture or UUID))
 [
-  { name = "node2", mac = "52:54:00:b2:2f:86", domain = "node2.example.com"},
-  { name = "node3", mac = "52:54:00:c3:61:77", domain = "node3.example.com"}
+  { name = "node2", mac = "52:54:00:b2:2f:86", domain = "node2.example.com", {"uuid":"123e4567-e89b-12d3-a456-426614174051"}},
+  { name = "node3", mac = "52:54:00:c3:61:77", domain = "node3.example.com", {"uuid":"123e4567-e89b-12d3-a456-426614174083"}}
 ]
 EOD
   default     = []

--- a/bare-metal/flatcar-linux/kubernetes/worker/butane/install.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/worker/butane/install.yaml
@@ -30,7 +30,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -ex
-          curl --retry 10 "${ignition_endpoint}?mac=${mac}&os=installed" -o ignition.json
+          curl --retry 10 "${ignition_endpoint}?${extra_selectors}mac=${mac}&os=installed" -o ignition.json
           flatcar-install \
             -d ${install_disk} \
             -C ${os_channel} \

--- a/bare-metal/flatcar-linux/kubernetes/worker/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/worker/variables.tf
@@ -98,6 +98,12 @@ variable "kernel_args" {
   default     = []
 }
 
+variable "extra_selectors" {
+  type        = map(string)
+  description = "Additional identifying fields"
+  default     = {}
+}
+
 # unofficial, undocumented, unsupported
 
 variable "service_cidr" {

--- a/bare-metal/flatcar-linux/kubernetes/workers.tf
+++ b/bare-metal/flatcar-linux/kubernetes/workers.tf
@@ -10,9 +10,10 @@ module "workers" {
   os_version             = var.os_version
 
   # machine
-  name   = var.workers[count.index].name
-  mac    = var.workers[count.index].mac
-  domain = var.workers[count.index].domain
+  name            = var.workers[count.index].name
+  mac             = var.workers[count.index].mac
+  domain          = var.workers[count.index].domain
+  extra_selectors = var.workers[count.index].extra_selectors
 
   # configuration
   kubeconfig            = module.bootstrap.kubeconfig-kubelet


### PR DESCRIPTION
A MAC address is only composed of 48 bits of which the first 24 bits can be determined as they are the OUI, which really only leaves about 24 random bits. Furthermore, a MAC address can easily be spoofed, which means using only the MAC for machine identification may become a vulnerability. This commit concerns the bare-metal/flatcar-linux folder and adds an optional field in the controllers and workers variables as well as a variable in the worker/variables.tf file. It defaults on {}. For example, it can be used to add a field based on the machine's uuid, which is 128 bits long, and thus make bruteforcing much harder (48 bits --> 48 * 128 bits).